### PR TITLE
Fix: clarifyObject throws error when options is null

### DIFF
--- a/Facebook-Dont-Track-Me.user.js
+++ b/Facebook-Dont-Track-Me.user.js
@@ -241,7 +241,7 @@ if (location.hostname.includes('facebook.com')) {
 
 document.addEventListener('readystatechange', () => {
   const sp = new URLSearchParams(location.hash);
-  const options = location.hostname.includes('facebook.com') ? { hard: true } : null;
+  const options = location.hostname.includes('facebook.com') ? { hard: true } : {};
   const goodSearch = new URLSearchParams(clarifyObject(sp, options)).toString();
   const goodURL = newURL(location.href);
   goodURL.search = goodSearch;


### PR DESCRIPTION
It will throw an error whenever the website is not facebook